### PR TITLE
Constants, Msg objects

### DIFF
--- a/src/genjs/generate.py
+++ b/src/genjs/generate.py
@@ -531,6 +531,7 @@ def write_srv_component(s, spec, context, parent):
     write_message_definition(s, context, spec)
     s.write('};')
     s.newline()
+    write_constants(s, spec)
 
 def write_srv_end(s, name):
     s.write('module.exports = {')


### PR DESCRIPTION
Adds constants to generated message files. You can now create instances of message objects that have default values. Users can optionally serialize these or json.
