### PR TITLE
Fixes gennodejs in install space

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ set(base_files
   src/gennodejs/base_deserialize.js
   src/gennodejs/find.js)
 
-file(COPY ${base_files} DESTINATION ${CATKIN_DEVEL_PREFIX}/share/gennodejs)
 install(FILES ${base_files}
   DESTINATION ${CATKIN_GLOBAL_SHARE_DESTINATION}/gennodejs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,9 @@ set(base_files
   src/gennodejs/base_deserialize.js
   src/gennodejs/find.js)
 
-file(COPY ${base_files} DESTINATION ${CATKIN_DEVEL_PREFIX}/share/node_js)
+file(COPY ${base_files} DESTINATION ${CATKIN_DEVEL_PREFIX}/share/gennodejs)
 install(FILES ${base_files}
-  DESTINATION ${CATKIN_GLOBAL_SHARE_DESTINATION}/node_js)
+  DESTINATION ${CATKIN_GLOBAL_SHARE_DESTINATION}/gennodejs)
 
 # drop marker file to prevent rospack from spending time on crawling this folder
 #file(WRITE ${CATKIN_DEVEL_PREFIX}/share/nodejs/rospack_nosubdirs "")

--- a/cmake/gennodejs-extras.cmake.em
+++ b/cmake/gennodejs-extras.cmake.em
@@ -44,14 +44,17 @@ macro(_generate_srv_nodejs ARG_PKG ARG_SRV ARG_IFLAGS ARG_MSG_DEPS ARG_GEN_OUTPU
   _generate_nodejs(${ARG_PKG} ${ARG_SRV} "${ARG_IFLAGS}" "${ARG_MSG_DEPS}" "${ARG_GEN_OUTPUT_DIR}/srv")
 endmacro()
 
-macro(_generate_module_nodejs ARG_PKG ARG_GEN_OUTPUT_DIR ARG_GENERATED_FILES)
-  set(base_files
-    "${JS_FILES_DIR}/base_serialize.js"
-    "${JS_FILES_DIR}/base_deserialize.js"
-    "${JS_FILES_DIR}/find.js")
+set(base_files
+  "${JS_FILES_DIR}/base_serialize.js"
+  "${JS_FILES_DIR}/base_deserialize.js"
+  "${JS_FILES_DIR}/find.js")
 
-    file(COPY ${base_files} DESTINATION ${ARG_GEN_OUTPUT_DIR})
+macro(_generate_module_nodejs ARG_PKG ARG_GEN_OUTPUT_DIR ARG_GENERATED_FILES)
+    file(COPY ${base_files} DESTINATION "${ARG_GEN_OUTPUT_DIR}/../..")
 endmacro()
+
+install(FILES ${base_files}
+  DESTINATION ${CATKIN_GLOBAL_SHARE_DESTINATION}/gennodejs)
 
 set(node_js_INSTALL_DIR share/gennodejs)
 set(gennodejs_INSTALL_DIR ${node_js_INSTALL_DIR}/ros)

--- a/cmake/gennodejs-extras.cmake.em
+++ b/cmake/gennodejs-extras.cmake.em
@@ -1,9 +1,11 @@
 @[if DEVELSPACE]@
 # bin variable in develspace
 set(GENNODEJS_BIN "@(CMAKE_CURRENT_SOURCE_DIR)/scripts/gen_nodejs.py")
+set(JS_FILES_DIR "@(CMAKE_CURRENT_SOURCE_DIR)/src/gennodejs")
 @[else]@
 # bin variable in installspace
 set(GENNODEJS_BIN "${gennodejs_DIR}/../../../@(CATKIN_PACKAGE_BIN_DESTINATION)/gen_nodejs.py")
+set(JS_FILES_DIR "${gennodejs_DIR}/../../../@(CATKIN_PACKAGE_SHARE_DESTINATION)")
 @[end if]@
 
 # Generate .msg or .srv -> .js
@@ -43,7 +45,13 @@ macro(_generate_srv_nodejs ARG_PKG ARG_SRV ARG_IFLAGS ARG_MSG_DEPS ARG_GEN_OUTPU
 endmacro()
 
 macro(_generate_module_nodejs ARG_PKG ARG_GEN_OUTPUT_DIR ARG_GENERATED_FILES)
+  set(base_files
+    "${JS_FILES_DIR}/base_serialize.js"
+    "${JS_FILES_DIR}/base_deserialize.js"
+    "${JS_FILES_DIR}/find.js")
+
+    file(COPY ${base_files} DESTINATION ${ARG_GEN_OUTPUT_DIR})
 endmacro()
 
-set(node_js_INSTALL_DIR share/node_js)
+set(node_js_INSTALL_DIR share/gennodejs)
 set(gennodejs_INSTALL_DIR ${node_js_INSTALL_DIR}/ros)

--- a/src/gennodejs/find.js
+++ b/src/gennodejs/find.js
@@ -22,7 +22,7 @@ let path = require('path');
 
 let cmakePath = process.env.CMAKE_PREFIX_PATH;
 let cmakePaths = cmakePath.split(':');
-let jsMsgPath = 'share/node_js/ros';
+let jsMsgPath = 'share/gennodejs/ros';
 
 let packagePaths = {};
 

--- a/src/gennodejs/generate.py
+++ b/src/gennodejs/generate.py
@@ -230,9 +230,9 @@ def write_requires(s, spec, previous_packages=None, prev_deps=None, isSrv=False)
     if previous_packages is None:
         s.write('"use strict";')
         s.newline()
-        s.write('let _serializer = require(\'../base_serialize.js\');')
-        s.write('let _deserializer = require(\'../base_deserialize.js\');')
-        s.write('let _finder = require(\'../find.js\');')
+        s.write('let _serializer = require(\'../../../base_serialize.js\');')
+        s.write('let _deserializer = require(\'../../../base_deserialize.js\');')
+        s.write('let _finder = require(\'../../../find.js\');')
         previous_packages = {}
     if prev_deps is None:
         prev_deps = []

--- a/src/gennodejs/generate.py
+++ b/src/gennodejs/generate.py
@@ -195,7 +195,7 @@ def find_path_from_cmake_path(path):
     return None
 
 def find_path_for_package(package):
-    return find_path_from_cmake_path(pjoin('share/node_js/ros', package))
+    return find_path_from_cmake_path(pjoin('share/gennodejs/ros', package))
 
 def find_requires(spec):
     found_packages = {}
@@ -230,9 +230,9 @@ def write_requires(s, spec, previous_packages=None, prev_deps=None, isSrv=False)
     if previous_packages is None:
         s.write('"use strict";')
         s.newline()
-        s.write('let _serializer = require(\'../../../base_serialize.js\');')
-        s.write('let _deserializer = require(\'../../../base_deserialize.js\');')
-        s.write('let _finder = require(\'../../../find.js\');')
+        s.write('let _serializer = require(\'../base_serialize.js\');')
+        s.write('let _deserializer = require(\'../base_deserialize.js\');')
+        s.write('let _finder = require(\'../find.js\');')
         previous_packages = {}
     if prev_deps is None:
         prev_deps = []


### PR DESCRIPTION
This should fix operation of gennodejs from install space. I ran an install build with gennodejs in one workspace, created an overlay for that workspace with some message packages and built (devel and install) without issues. This should also solve problems using catkin tools with --link-devel because the js files provided by gennodejs are copied into each module. In my overlaid workspace I ran rosjs' test scripts and example without issue. This resolves the `CMake Error` in #8 .
