### PR TITLE
Revert shared base files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ set(base_files
   src/gennodejs/base_deserialize.js
   src/gennodejs/find.js)
 
-file(COPY ${base_files} DESTINATION ${CATKIN_DEVEL_PREFIX}/share/gennodejs)
 install(FILES ${base_files}
   DESTINATION ${CATKIN_GLOBAL_SHARE_DESTINATION}/gennodejs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(base_files
   src/gennodejs/base_deserialize.js
   src/gennodejs/find.js)
 
+file(COPY ${base_files} DESTINATION ${CATKIN_DEVEL_PREFIX}/share/gennodejs)
 install(FILES ${base_files}
   DESTINATION ${CATKIN_GLOBAL_SHARE_DESTINATION}/gennodejs)
 

--- a/cmake/gennodejs-extras.cmake.em
+++ b/cmake/gennodejs-extras.cmake.em
@@ -44,17 +44,14 @@ macro(_generate_srv_nodejs ARG_PKG ARG_SRV ARG_IFLAGS ARG_MSG_DEPS ARG_GEN_OUTPU
   _generate_nodejs(${ARG_PKG} ${ARG_SRV} "${ARG_IFLAGS}" "${ARG_MSG_DEPS}" "${ARG_GEN_OUTPUT_DIR}/srv")
 endmacro()
 
-set(base_files
-  "${JS_FILES_DIR}/base_serialize.js"
-  "${JS_FILES_DIR}/base_deserialize.js"
-  "${JS_FILES_DIR}/find.js")
-
 macro(_generate_module_nodejs ARG_PKG ARG_GEN_OUTPUT_DIR ARG_GENERATED_FILES)
-    file(COPY ${base_files} DESTINATION "${ARG_GEN_OUTPUT_DIR}/../..")
-endmacro()
+  set(base_files
+    "${JS_FILES_DIR}/base_serialize.js"
+    "${JS_FILES_DIR}/base_deserialize.js"
+    "${JS_FILES_DIR}/find.js")
 
-install(FILES ${base_files}
-  DESTINATION ${CATKIN_GLOBAL_SHARE_DESTINATION}/gennodejs)
+    file(COPY ${base_files} DESTINATION ${ARG_GEN_OUTPUT_DIR})
+endmacro()
 
 set(node_js_INSTALL_DIR share/gennodejs)
 set(gennodejs_INSTALL_DIR ${node_js_INSTALL_DIR}/ros)

--- a/src/gennodejs/generate.py
+++ b/src/gennodejs/generate.py
@@ -232,9 +232,9 @@ def write_requires(s, spec, previous_packages=None, prev_deps=None, isSrv=False)
     if previous_packages is None:
         s.write('"use strict";')
         s.newline()
-        s.write('let _serializer = require(\'../../../base_serialize.js\');')
-        s.write('let _deserializer = require(\'../../../base_deserialize.js\');')
-        s.write('let _finder = require(\'../../../find.js\');')
+        s.write('let _serializer = require(\'../base_serialize.js\');')
+        s.write('let _deserializer = require(\'../base_deserialize.js\');')
+        s.write('let _finder = require(\'../find.js\');')
         previous_packages = {}
     if prev_deps is None:
         prev_deps = []


### PR DESCRIPTION
The discussion in #7 led to us reusing the "base files" (`base_serialize.js`, `base_deserialize.js`, and `find.js`) for every package. This causes package to overwrite files written by other packages, which triggers a buildfarm failure for every message package:
http://build.ros.org/job/Kbin_dJ64__rosgraph_msgs__debian_jessie_amd64__binary/4/console

This commit brings us back to our original "copy base files in every message package" state. Dirk recommended we go the original copy route: https://github.com/ros/rosdistro/pull/11548
