### PR TITLE
Fix UTF-8 serialization

### DIFF
--- a/src/gennodejs/generate.py
+++ b/src/gennodejs/generate.py
@@ -618,7 +618,7 @@ def write_get_message_size(s, spec, search_path):
                                 raise Exception('Unexpected field {} with type {} has unknown length'.format(f.name, f.base_type))
                             # it's a string array!
                             len_constant_length_fields += 4
-                            line_to_write = 'length += object.{}.length;'.format(f.name)
+                            line_to_write = 'length += Buffer.byteLength(object.{}, \'utf8\');'.format(f.name)
                         else:
                             (package, msg_type) = f.base_type.split('/')
                             samePackage = spec.package == package

--- a/src/gennodejs/generate.py
+++ b/src/gennodejs/generate.py
@@ -597,7 +597,7 @@ def write_get_message_size(s, spec, search_path):
                                 if not is_string(f.base_type):
                                     raise Exception('Unexpected field {} with type {} has unknown length'.format(f.name, f.base_type))
                                 # it's a string array!
-                                line_to_write = 'length += 4 + val.length;'
+                                line_to_write = 'length += 4 + _getByteLength(val);'
                             else:
                                 (package, msg_type) = f.base_type.split('/')
                                 samePackage = spec.package == package

--- a/src/gennodejs/generate.py
+++ b/src/gennodejs/generate.py
@@ -618,7 +618,7 @@ def write_get_message_size(s, spec, search_path):
                                 raise Exception('Unexpected field {} with type {} has unknown length'.format(f.name, f.base_type))
                             # it's a string array!
                             len_constant_length_fields += 4
-                            line_to_write = 'length += Buffer.byteLength(object.{}, \'utf8\');'.format(f.name)
+                            line_to_write = 'length += _getByteLength(object.{});'.format(f.name)
                         else:
                             (package, msg_type) = f.base_type.split('/')
                             samePackage = spec.package == package


### PR DESCRIPTION
This is #17 with the [requested review fix](https://github.com/RethinkRobotics-opensource/gennodejs/pull/17#discussion_r294454869) to use `_getByteLength()` instead of the `Buffer` interface.

Fixes #18 