### PR TITLE
feat: add support for quotes in string constants

### DIFF
--- a/src/gennodejs/generate.py
+++ b/src/gennodejs/generate.py
@@ -719,7 +719,7 @@ def write_constants(s, spec):
         with Indent(s):
             for c in spec.constants:
                 if is_string(c.type):
-                    s.write('{}: \'{}\','.format(c.name.upper(), c.val))
+                    s.write('{}: \'{}\','.format(c.name.upper(), c.val.replace("'", "\\'")))
                 elif is_bool(c.type):
                     s.write('{}: {},'.format(c.name.upper(), 'true' if c.val else 'false'))
                 else:


### PR DESCRIPTION
Added support for quotes in string constants just in case someone wants to use quotes.

Related problem: https://github.com/fkie/multimaster_fkie/pull/118